### PR TITLE
[IPMPROG-1780] 2.3.1.md: undo the hotfix and use double-quotes…

### DIFF
--- a/ipm/2.3.1.md
+++ b/ipm/2.3.1.md
@@ -12,7 +12,7 @@ IPM Editions 2.3.1 is delivered in the following format(s):
 
 ## Automation:
 * New cluster shutdown option is available to ensure automatic restart of non-critical VMs when the cluster comes back
-* Dynamic groups now have exclusion criteria ('is not','does not contain') in addition to the existing ones ('is', 'contains')
+* Dynamic groups now have exclusion criteria ("is not", "does not contain") in addition to the existing ones ("is", "contains")
 
 ## Licensing:
 * Licensing page is now enriched to contain all useful information and history on renew, upgrade, increase an existing entitlement


### PR DESCRIPTION
… (and add a space between words)

NOTE: Used the branch to test that the quotes propagate correctly all the way to published OS image manifests